### PR TITLE
Add multi-output handling

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,7 @@
 name: Python package
 
 on:
-  push:
+  pull_request:
     branches: [ master ]
 
 jobs:
@@ -25,10 +25,3 @@ jobs:
       run: make test
     - name: Build package
       run: make build-package
-    - name: Publish to PyPI
-      if: github.repository == 'PolicyEngine/synthimpute'
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI }}
-        skip_existing: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,12 +11,10 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -30,6 +28,7 @@ jobs:
     - name: Build package
       run: make build-package
     - name: Publish to PyPI
+      if: github.repository == 'PolicyEngine/synthimpute'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,20 +23,15 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Install package
-      run: |
-        pip install -e .[test]
-    - name: Test with pytest
-      run: |
-        pytest
+      run: make install
+    - name: Test package
+      run: make test
+    - name: Build package
+      run: make build-package
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI }}
+        skip_existing: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+format:
+	black . -l 79

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,9 @@
 format:
 	black . -l 79
+install:
+	pip install -e .[dev]
+test:
+	pytest
+build-package:
+	rm -rf dist build
+	python setup.py sdist bdist_wheel

--- a/examples/nearest_record.ipynb
+++ b/examples/nearest_record.ipynb
@@ -34,9 +34,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mpg = pd.read_csv('https://raw.githubusercontent.com/mwaskom/seaborn-data/master/mpg.csv')\n",
+    "mpg = pd.read_csv(\n",
+    "    \"https://raw.githubusercontent.com/mwaskom/seaborn-data/master/mpg.csv\"\n",
+    ")\n",
     "# Drop class columns and sometimes-missing horsepower.\n",
-    "mpg.drop(['origin', 'name', 'horsepower'], axis=1, inplace=True)"
+    "mpg.drop([\"origin\", \"name\", \"horsepower\"], axis=1, inplace=True)"
    ]
   },
   {
@@ -64,7 +66,7 @@
     }
    ],
    "source": [
-    "synth = si.rf_synth(mpg, ['cylinders'], random_state=0)"
+    "synth = si.rf_synth(mpg, [\"cylinders\"], random_state=0)"
    ]
   },
   {
@@ -155,7 +157,7 @@
     }
    ],
    "source": [
-    "nearest = si.nearest_record(synth, mpg, metric='euclidean')\n",
+    "nearest = si.nearest_record(synth, mpg, metric=\"euclidean\")\n",
     "nearest.head()"
    ]
   },

--- a/examples/nearest_synth_test_train.ipynb
+++ b/examples/nearest_synth_test_train.ipynb
@@ -35,9 +35,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mpg = pd.read_csv('https://raw.githubusercontent.com/mwaskom/seaborn-data/master/mpg.csv')\n",
+    "mpg = pd.read_csv(\n",
+    "    \"https://raw.githubusercontent.com/mwaskom/seaborn-data/master/mpg.csv\"\n",
+    ")\n",
     "# Drop class columns and sometimes-missing horsepower.\n",
-    "mpg.drop(['origin', 'name', 'horsepower'], axis=1, inplace=True)"
+    "mpg.drop([\"origin\", \"name\", \"horsepower\"], axis=1, inplace=True)"
    ]
   },
   {
@@ -77,7 +79,7 @@
     }
    ],
    "source": [
-    "synth = si.rf_synth(train, ['cylinders'], random_state=0)"
+    "synth = si.rf_synth(train, [\"cylinders\"], random_state=0)"
    ]
   },
   {

--- a/examples/rf_quantile.ipynb
+++ b/examples/rf_quantile.ipynb
@@ -325,8 +325,7 @@
     "N_TRAIN = 1000\n",
     "N_NEW = 1000\n",
     "n = N_TRAIN + N_NEW\n",
-    "x = pd.DataFrame({'x1': np.random.randn(n),\n",
-    "                  'x2': np.random.randn(n)})\n",
+    "x = pd.DataFrame({\"x1\": np.random.randn(n), \"x2\": np.random.randn(n)})\n",
     "# Construct example relationship.\n",
     "y = x.x1 + np.power(x.x2, 3) + np.random.randn(n)\n",
     "si.rf_impute(x.iloc[:N_TRAIN], y.iloc[:N_TRAIN], x.iloc[N_TRAIN:])"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-numpy
-pandas
-scikit-learn
-statsmodels

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="synthimpute",
-    version="0.1",
+    version="0.2.0",
     description="Python package for data synthesis and imputation using parametric and nonparametric methods, and evaluation of these methods.",
     url="http://github.com/PSLmodels/synthimpute",
     author="Max Ghenis",

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,10 @@ setup(
         "statsmodels",
         "scipy",
     ],
+    extras_require={
+        "dev": {
+            "black",
+        }
+    },
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,15 @@ setup(
         "scikit-learn",
         "statsmodels",
         "scipy",
+        "tqdm",
     ],
     extras_require={
         "dev": {
             "black",
+            "flake8",
+            "pytest",
+            "wheel",
+            "coverage",
         }
     },
     zip_safe=False,

--- a/synthimpute/rf_impute.py
+++ b/synthimpute/rf_impute.py
@@ -60,7 +60,7 @@ def rf_impute(
     rtol: float = 0.05,
     rf: ensemble.RandomForestRegressor = None,
     verbose: bool = False,
-    **kwargs
+    **kwargs,
 ):
     """Impute labels from a training set to a new data set using
        random forests quantile regression.
@@ -103,26 +103,33 @@ def rf_impute(
             else range(len(y_train.columns))
         )
         for i in task:
+            column = y_train.columns[i]
             not_yet_predicted_cols = y_train.columns[i:]
-            
+
             x_train_expanded = pd.concat(
                 [x_train, y_train.drop(not_yet_predicted_cols, axis=1)],
                 axis=1,
             )
             if type(x_train).__name__ == "MicroDataFrame":
-                x_train_expanded = type(x_train)(x_train_expanded, weights=x_train.weights)
-            
+                x_train_expanded = type(x_train)(
+                    x_train_expanded, weights=x_train.weights
+                )
+
             x_new_expanded = pd.concat([x_new, result], axis=1)
 
             if type(x_new).__name__ == "MicroDataFrame":
-                x_new_expanded = type(x_new)(x_new_expanded, weights=x_new.weights)
+                x_new_expanded = type(x_new)(
+                    x_new_expanded, weights=x_new.weights
+                )
 
             if verbose:
-                task.set_description(f"Imputing column {y_train.columns[i]} (targeting {int(target or y_train[y_train.columns[i]].sum()/1e9):,}bn)")
+                task.set_description(
+                    f"Imputing column {column} (targeting {int(target or y_train[column].sum()/1e9):,}bn)"
+                )
 
             result[y_train.columns[i]] = rf_impute(
                 x_train=x_train_expanded,
-                y_train=y_train[y_train.columns[i]],
+                y_train=y_train[column],
                 x_new=x_new_expanded,
                 random_state=random_state,
                 sample_weight_train=sample_weight_train,
@@ -132,7 +139,7 @@ def rf_impute(
                 rtol=rtol,
                 rf=rf,
                 verbose=verbose,
-                **kwargs
+                **kwargs,
             )
         return result
 
@@ -146,7 +153,7 @@ def rf_impute(
     ):
         sample_weight_train = x_train.weights
         new_weight = x_new.weights
-    
+
         if target is None:
             target = y_train.sum()
 

--- a/synthimpute/synthesize.py
+++ b/synthimpute/synthesize.py
@@ -17,7 +17,7 @@ def rf_synth(
     Args:
         X: Data to synthesize, as a pandas DataFrame.
         seed_cols: Columns to seed the synthesis, via sampling with replacement.
-        classification_cols: Optional list of numeric columns to synthesize via classification. 
+        classification_cols: Optional list of numeric columns to synthesize via classification.
                              String columns are classified by default.
         n: Number of records to produce. Defaults to the number of records in X.
         trees: Number of trees in each model (n_estimators).
@@ -31,10 +31,15 @@ def rf_synth(
     # Start with the seed synthesis.
     if n is None:
         n = X.shape[0]
-    synth = X.copy()[seed_cols].sample(n=n, replace=True, random_state=random_state)
+    synth = X.copy()[seed_cols].sample(
+        n=n, replace=True, random_state=random_state
+    )
     # Initialize random forests model object.
     rf = ensemble.RandomForestRegressor(
-        n_estimators=trees, min_samples_leaf=1, random_state=random_state, n_jobs=-1
+        n_estimators=trees,
+        min_samples_leaf=1,
+        random_state=random_state,
+        n_jobs=-1,
     )  # Use maximum number of cores.
     # Loop through each variable.
     if synth_cols is None:

--- a/synthimpute/tests/test_rf_impute.py
+++ b/synthimpute/tests/test_rf_impute.py
@@ -19,7 +19,9 @@ def test_rf_impute():
     # Try with some args.
     si.rf_impute(x_train, y_train, x_test, random_state=10, n_estimators=200)
     # Try with sample_weight_train.
-    si.rf_impute(x_train, y_train, x_test, sample_weight_train=np.random.randn(N_TRAIN))
+    si.rf_impute(
+        x_train, y_train, x_test, sample_weight_train=np.random.randn(N_TRAIN)
+    )
     # Check that values are higher when using a higher mean quantile.
     higher_q = si.rf_impute(x_train, y_train, x_test, mean_quantile=0.9)
     assert higher_q.mean() > base.mean()

--- a/synthimpute/trees.py
+++ b/synthimpute/trees.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 def decision_tree_regressor_predict_proba(X_train, y_train, X_test, **kwargs):
     """Trains DecisionTreeRegressor model and predicts probabilities of each y.
-    
+
     Args:
         X_train: Training features.
         y_train: Training labels.
@@ -12,7 +12,7 @@ def decision_tree_regressor_predict_proba(X_train, y_train, X_test, **kwargs):
         **kwargs: Other arguments passed to DecisionTreeRegressor.
 
     Returns:
-        DataFrame with columns for record_id (row of X_test), y 
+        DataFrame with columns for record_id (row of X_test), y
         (predicted value), and prob (of that y value).
         The sum of prob equals 1 for each record_id.
     """


### PR DESCRIPTION
This adds multi-output prediction, by predicting each output variable separately. `y_train` can now be a `DataFrame`, as well as a `Series`.

@MaxGhenis outputs are predicted independently of each other. Should they be predicted sequentially?